### PR TITLE
feat: revamp db schema

### DIFF
--- a/prisma/migrations/20250224102119_add_user_stats/migration.sql
+++ b/prisma/migrations/20250224102119_add_user_stats/migration.sql
@@ -1,0 +1,97 @@
+/*
+  Warnings:
+
+  - You are about to drop the `friends` table. If the table is not empty, all the data it contains will be lost.
+  - You are about to drop the `users` table. If the table is not empty, all the data it contains will be lost.
+
+*/
+-- CreateEnum
+CREATE TYPE "StatisticPeriod" AS ENUM ('weekly', 'monthly', 'semiannual', 'annual');
+
+-- DropForeignKey
+ALTER TABLE "friends" DROP CONSTRAINT "friends_user_one_id_fkey";
+
+-- DropForeignKey
+ALTER TABLE "friends" DROP CONSTRAINT "friends_user_second_id_fkey";
+
+-- DropForeignKey
+ALTER TABLE "song_of_the_day" DROP CONSTRAINT "song_of_the_day_user_id_fkey";
+
+-- DropIndex
+DROP INDEX "song_of_the_day_trackId_key";
+
+-- AlterTable
+ALTER TABLE "song_of_the_day" ADD COLUMN     "mood" TEXT,
+ADD COLUMN     "note" TEXT;
+
+-- DropTable
+DROP TABLE "friends";
+
+-- DropTable
+DROP TABLE "users";
+
+-- CreateTable
+CREATE TABLE "user" (
+    "id" TEXT NOT NULL,
+    "username" TEXT NOT NULL,
+    "passwordHash" TEXT NOT NULL,
+    "is_verified" BOOLEAN NOT NULL DEFAULT false,
+    "email" TEXT NOT NULL,
+    "bio" TEXT,
+    "photo_url" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "user_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "friend" (
+    "id" TEXT NOT NULL,
+    "status" "FriendStatus" NOT NULL,
+    "user_one_id" TEXT NOT NULL,
+    "user_two_id" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "friend_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "user_statistic" (
+    "id" TEXT NOT NULL,
+    "user_id" TEXT NOT NULL,
+    "period" "StatisticPeriod" NOT NULL,
+    "totalTracks" INTEGER NOT NULL DEFAULT 0,
+    "totalDuration" INTEGER NOT NULL DEFAULT 0,
+    "uniqueArtists" INTEGER NOT NULL DEFAULT 0,
+    "vibe" TEXT,
+    "topArtistsIds" TEXT[],
+    "topTracksIds" TEXT[],
+    "topAlbumsIds" TEXT[],
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "user_statistic_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "user_username_key" ON "user"("username");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "user_passwordHash_key" ON "user"("passwordHash");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "user_email_key" ON "user"("email");
+
+-- AddForeignKey
+ALTER TABLE "friend" ADD CONSTRAINT "friend_user_one_id_fkey" FOREIGN KEY ("user_one_id") REFERENCES "user"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "friend" ADD CONSTRAINT "friend_user_two_id_fkey" FOREIGN KEY ("user_two_id") REFERENCES "user"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "song_of_the_day" ADD CONSTRAINT "song_of_the_day_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "user"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "user_statistic" ADD CONSTRAINT "user_statistic_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "user"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -10,7 +10,7 @@ datasource db {
 model User {
     id           String   @id @default(cuid())
     username     String   @unique
-    passwordHash String   @unique
+    passwordHash String
     isVerified   Boolean  @default(false) @map("is_verified")
     email        String   @unique
     bio          String?

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -8,40 +8,46 @@ datasource db {
 }
 
 model User {
-    id         String   @id @default(cuid())
-    username   String   @unique
-    isVerified Boolean  @default(false) @map("is_verified")
-    email      String   @unique
-    bio        String?
-    photoUrl   String?  @map("photo_url")
-    createdAt  DateTime @default(now())
-    updatedAt  DateTime @updatedAt
+    id           String   @id @default(cuid())
+    username     String   @unique
+    passwordHash String   @unique
+    isVerified   Boolean  @default(false) @map("is_verified")
+    email        String   @unique
+    bio          String?
+    photoUrl     String?  @map("photo_url")
+    createdAt    DateTime @default(now())
+    updatedAt    DateTime @updatedAt
 
-    friendsInitiated Friends[]      @relation("UserOne")
-    friendsReceived  Friends[]      @relation("UserTwo")
-    Track            SongOfTheDay[]
+    friendsInitiated Friend[]        @relation("UserOne")
+    friendsReceived  Friend[]        @relation("UserTwo")
+    songOfTheDay     SongOfTheDay[]
+    userStatistics   UserStatistic[]
 
-    @@map("users")
+    @@map("user")
 }
 
-model Friends {
+model Friend {
     id        String       @id @default(cuid())
     status    FriendStatus
     userOneId String       @map("user_one_id")
-    userTwoId String       @map("user_second_id")
+    userTwoId String       @map("user_two_id")
     createdAt DateTime     @default(now())
     updatedAt DateTime     @updatedAt
 
     userOne User @relation("UserOne", fields: [userOneId], references: [id])
     userTwo User @relation("UserTwo", fields: [userTwoId], references: [id])
 
-    @@map("friends")
+    @@map("friend")
 }
 
 model SongOfTheDay {
     id        String   @id @default(cuid())
     userId    String   @map("user_id")
-    trackId   String   @unique
+    trackId   String
+    trackName String
+    photoUrl  String?  @map("photo_url")
+    note      String?
+    mood      String?
     setAt     DateTime @default(now())
     createdAt DateTime @default(now())
     updatedAt DateTime @updatedAt
@@ -51,8 +57,37 @@ model SongOfTheDay {
     @@map("song_of_the_day")
 }
 
+model UserStatistic {
+    id            String          @id @default(cuid())
+    userId        String          @unique @map("user_id")
+    period        StatisticPeriod
+    totalTracks   Int             @default(0)
+    totalDuration Int             @default(0)
+    uniqueArtists Int             @default(0)
+    vibe          String?
+    topArtistsIds String[]
+    topTracksIds  String[]
+    topAlbumsIds  String[]
+    topGenresIds  String[]
+    createdAt     DateTime        @default(now())
+    updatedAt     DateTime        @updatedAt
+
+    user User @relation(fields: [userId], references: [id])
+
+    @@map("user_statistic")
+}
+
+// TODO: Add User-Genre table for discovery feature
+
+enum StatisticPeriod {
+    WEEKLY     @map("weekly")
+    MONTHLY    @map("monthly")
+    SEMIANNUAL @map("semiannual")
+    ANNUAL     @map("annual")
+}
+
 enum FriendStatus {
-    ACTIVE  @map("active")
-    BLOCKED @map("blocked")
-    REMOVED @map("removed")
+    ACTIVE   @map("active")
+    BLOCKED  @map("blocked")
+    INACTIVE @map("inactive")
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -44,8 +44,6 @@ model SongOfTheDay {
     id        String   @id @default(cuid())
     userId    String   @map("user_id")
     trackId   String
-    trackName String
-    photoUrl  String?  @map("photo_url")
     note      String?
     mood      String?
     setAt     DateTime @default(now())
@@ -59,7 +57,7 @@ model SongOfTheDay {
 
 model UserStatistic {
     id            String          @id @default(cuid())
-    userId        String          @unique @map("user_id")
+    userId        String          @map("user_id")
     period        StatisticPeriod
     totalTracks   Int             @default(0)
     totalDuration Int             @default(0)
@@ -68,7 +66,6 @@ model UserStatistic {
     topArtistsIds String[]
     topTracksIds  String[]
     topAlbumsIds  String[]
-    topGenresIds  String[]
     createdAt     DateTime        @default(now())
     updatedAt     DateTime        @updatedAt
 
@@ -87,7 +84,7 @@ enum StatisticPeriod {
 }
 
 enum FriendStatus {
-    ACTIVE   @map("active")
-    BLOCKED  @map("blocked")
-    INACTIVE @map("inactive")
+    ACTIVE  @map("active")
+    BLOCKED @map("blocked")
+    REMOVED @map("removed")
 }


### PR DESCRIPTION
## Feature

Added the following changes to the db schema
- `passwordHash` field to `User` table
- `note` & `mood` field to `SongOfTheDay` table
- `UserStatistic` table for recap of spotify wraps
- refactor naming of tables & fields

## Issue
- Unable to change enum field in prisma ([link](https://github.com/prisma/prisma/issues/24292))
- Prisma not giving good error desc ([link](https://github.com/prisma/prisma/issues/15295))

## Note
- Need to add user-genre table for discovery feature in future