### PR TITLE
feat: friend endpoints

### DIFF
--- a/internal/database/db.go
+++ b/internal/database/db.go
@@ -13,6 +13,10 @@ type Service interface {
 	CreateSotd(ctx context.Context, userID, trackID, note, mood string) (*db.SongOfTheDayModel, error)
 	GetSotd(ctx context.Context, userId string, date time.Time) (*db.SongOfTheDayModel, error)
 	UpdateSotd(ctx context.Context, sotdId, trackId, note, mood string) (*db.SongOfTheDayModel, error)
+	AddFriend(ctx context.Context, userId, friendId string) (*db.FriendModel, error)
+	GetFriendRequests(ctx context.Context, userId string) ([]FriendWithUsers, error)
+	AcceptFriendRequest(ctx context.Context, userId, requestId string) (*db.FriendModel, error)
+	GetFriends(ctx context.Context, userId string) ([]FriendWithUsers, error)
 	Health() map[string]string
 	Close() error
 }

--- a/internal/database/friend.go
+++ b/internal/database/friend.go
@@ -1,0 +1,126 @@
+package database
+
+import (
+	"context"
+	"fmt"
+	db "fsd-backend/prisma/db"
+)
+
+type UserPublic struct {
+	ID       string `json:"id"`
+	Email    string `json:"email"`
+	Username string `json:"username"`
+}
+
+type FriendWithUsers struct {
+	ID        string          `json:"id"`
+	Status    db.FriendStatus `json:"status"`
+	UserOne   UserPublic      `json:"userOne"`
+	UserTwo   UserPublic      `json:"userTwo"`
+	CreatedAt string          `json:"createdAt"`
+	UpdatedAt string          `json:"updatedAt"`
+}
+
+func (s *service) AddFriend(ctx context.Context, userID, friendID string) (*db.FriendModel, error) {
+	userOne := userID
+	userTwo := friendID
+	existingFriend, err := s.client.Friend.FindFirst(
+		db.Friend.Or(
+			db.Friend.And(
+				db.Friend.UserOneID.Equals(userOne),
+				db.Friend.UserTwoID.Equals(userTwo),
+			),
+			db.Friend.And(
+				db.Friend.UserOneID.Equals(userTwo),
+				db.Friend.UserTwoID.Equals(userOne),
+			),
+		),
+	).Exec(ctx)
+	if err != nil && err.Error() != "ErrNotFound" {
+		return nil, err
+	}
+	if existingFriend != nil {
+		return nil, fmt.Errorf("friendship already exists")
+	}
+	return s.client.Friend.CreateOne(
+		db.Friend.Status.Set(db.FriendStatusPending),
+		db.Friend.UserOne.Link(db.User.ID.Equals(userOne)),
+		db.Friend.UserTwo.Link(db.User.ID.Equals(userTwo)),
+	).Exec(ctx)
+}
+
+func (s *service) GetFriendRequests(ctx context.Context, userId string) ([]FriendWithUsers, error) {
+	friendRequests, err := s.client.Friend.FindMany(
+		db.Friend.UserTwoID.Equals(userId),
+		db.Friend.Status.Equals(db.FriendStatusPending),
+	).With(
+		db.Friend.UserOne.Fetch(),
+		db.Friend.UserTwo.Fetch(),
+	).Exec(ctx)
+
+	if err != nil {
+		return nil, err
+	}
+	friendRequestsList := []FriendWithUsers{}
+	for _, f := range friendRequests {
+		friendRequestsList = append(friendRequestsList, FriendWithUsers{
+			ID:        f.ID,
+			Status:    f.Status,
+			UserOne:   UserPublic{ID: f.UserOne().ID, Email: f.UserOne().Email, Username: f.UserOne().Username},
+			UserTwo:   UserPublic{ID: f.UserTwo().ID, Email: f.UserTwo().Email, Username: f.UserTwo().Username},
+			CreatedAt: f.CreatedAt.String(),
+			UpdatedAt: f.UpdatedAt.String(),
+		})
+	}
+	return friendRequestsList, nil
+}
+
+func (s *service) AcceptFriendRequest(ctx context.Context, userId, requestId string) (*db.FriendModel, error) {
+	friend, err := s.client.Friend.FindUnique(
+		db.Friend.ID.Equals(requestId),
+	).Exec(ctx)
+
+	if err != nil {
+		return nil, fmt.Errorf("error finding friend request: %v", err)
+	}
+
+	if friend == nil || friend.UserTwoID != userId {
+		return nil, fmt.Errorf("friend request not found or not intended for this user")
+	}
+
+	return s.client.Friend.FindUnique(
+		db.Friend.ID.Equals(requestId),
+	).Update(
+		db.Friend.Status.Set(db.FriendStatusActive),
+	).Exec(ctx)
+}
+
+func (s *service) GetFriends(ctx context.Context, userId string) ([]FriendWithUsers, error) {
+	friends, err := s.client.Friend.FindMany(
+		db.Friend.Or(
+			db.Friend.UserOneID.Equals(userId),
+			db.Friend.UserTwoID.Equals(userId),
+		),
+		db.Friend.Status.Equals(db.FriendStatusActive),
+	).With(
+		db.Friend.UserOne.Fetch(),
+		db.Friend.UserTwo.Fetch(),
+	).Exec(ctx)
+
+	if err != nil {
+		return nil, err
+	}
+
+	friendList := []FriendWithUsers{}
+	for _, f := range friends {
+		friendList = append(friendList, FriendWithUsers{
+			ID:        f.ID,
+			Status:    f.Status,
+			UserOne:   UserPublic{ID: f.UserOne().ID, Email: f.UserOne().Email, Username: f.UserOne().Username},
+			UserTwo:   UserPublic{ID: f.UserTwo().ID, Email: f.UserTwo().Email, Username: f.UserTwo().Username},
+			CreatedAt: f.CreatedAt.String(),
+			UpdatedAt: f.UpdatedAt.String(),
+		})
+	}
+	return friendList, nil
+}

--- a/internal/database/friend.go
+++ b/internal/database/friend.go
@@ -61,16 +61,19 @@ func (s *service) GetFriendRequests(ctx context.Context, userId string) ([]Frien
 	if err != nil {
 		return nil, err
 	}
-	friendRequestsList := []FriendWithUsers{}
-	for _, f := range friendRequests {
-		friendRequestsList = append(friendRequestsList, FriendWithUsers{
+
+	fmt.Println(friendRequests)
+
+	friendRequestsList := make([]FriendWithUsers, len(friendRequests))
+	for i, f := range friendRequests {
+		friendRequestsList[i] = FriendWithUsers{
 			ID:        f.ID,
 			Status:    f.Status,
-			UserOne:   UserPublic{ID: f.UserOne().ID, Email: f.UserOne().Email, Username: f.UserOne().Username},
-			UserTwo:   UserPublic{ID: f.UserTwo().ID, Email: f.UserTwo().Email, Username: f.UserTwo().Username},
+			UserOne:   UserPublic{ID: f.UserOne().ID, Email: f.UserOne().Email, Username: f.UserOne().Name},
+			UserTwo:   UserPublic{ID: f.UserTwo().ID, Email: f.UserTwo().Email, Username: f.UserTwo().Name},
 			CreatedAt: f.CreatedAt.String(),
 			UpdatedAt: f.UpdatedAt.String(),
-		})
+		}
 	}
 	return friendRequestsList, nil
 }
@@ -110,17 +113,16 @@ func (s *service) GetFriends(ctx context.Context, userId string) ([]FriendWithUs
 	if err != nil {
 		return nil, err
 	}
-
-	friendList := []FriendWithUsers{}
-	for _, f := range friends {
-		friendList = append(friendList, FriendWithUsers{
+	friendList := make([]FriendWithUsers, len(friends))
+	for i, f := range friends {
+		friendList[i] = FriendWithUsers{
 			ID:        f.ID,
 			Status:    f.Status,
-			UserOne:   UserPublic{ID: f.UserOne().ID, Email: f.UserOne().Email, Username: f.UserOne().Username},
-			UserTwo:   UserPublic{ID: f.UserTwo().ID, Email: f.UserTwo().Email, Username: f.UserTwo().Username},
+			UserOne:   UserPublic{ID: f.UserOne().ID, Email: f.UserOne().Email, Username: f.UserOne().Name},
+			UserTwo:   UserPublic{ID: f.UserTwo().ID, Email: f.UserTwo().Email, Username: f.UserTwo().Name},
 			CreatedAt: f.CreatedAt.String(),
 			UpdatedAt: f.UpdatedAt.String(),
-		})
+		}
 	}
 	return friendList, nil
 }

--- a/internal/database/friend.go
+++ b/internal/database/friend.go
@@ -62,8 +62,6 @@ func (s *service) GetFriendRequests(ctx context.Context, userId string) ([]Frien
 		return nil, err
 	}
 
-	fmt.Println(friendRequests)
-
 	friendRequestsList := make([]FriendWithUsers, len(friendRequests))
 	for i, f := range friendRequests {
 		friendRequestsList[i] = FriendWithUsers{

--- a/internal/server/friend_handler.go
+++ b/internal/server/friend_handler.go
@@ -1,0 +1,70 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+func (s *Server) addFriendHandler(w http.ResponseWriter, r *http.Request) {
+	UserID := r.PathValue("userId")
+	type parameters struct {
+		FriendID string `json:"friend_id"`
+	}
+	decoder := json.NewDecoder(r.Body)
+	params := parameters{}
+	err := decoder.Decode(&params)
+	if err != nil {
+		respondWithError(w, http.StatusInternalServerError, "Couldn't decode parameters", err)
+		return
+	}
+
+	friend, err := s.db.AddFriend(r.Context(), UserID, params.FriendID)
+	if err != nil {
+		respondWithError(w, http.StatusInternalServerError, "Couldn't add friend", err)
+		return
+	}
+
+	respondWithJSON(w, http.StatusCreated, friend)
+}
+
+func (s *Server) getFriendRequestsHandler(w http.ResponseWriter, r *http.Request) {
+	UserID := r.PathValue("userId")
+	friendRequests, err := s.db.GetFriendRequests(r.Context(), UserID)
+	if err != nil {
+		respondWithError(w, http.StatusInternalServerError, "Couldn't get friend requests", err)
+		return
+	}
+	respondWithJSON(w, http.StatusOK, friendRequests)
+}
+
+func (s *Server) acceptFriendHandler(w http.ResponseWriter, r *http.Request) {
+	UserID := r.PathValue("userId")
+	type parameters struct {
+		RequestID string `json:"request_id"`
+	}
+
+	decoder := json.NewDecoder(r.Body)
+	params := parameters{}
+	err := decoder.Decode(&params)
+	if err != nil {
+		respondWithError(w, http.StatusInternalServerError, "Couldn't decode parameters", err)
+		return
+	}
+
+	friend, err := s.db.AcceptFriendRequest(r.Context(), UserID, params.RequestID)
+	if err != nil {
+		respondWithError(w, http.StatusInternalServerError, "Couldn't accept friend", err)
+		return
+	}
+	respondWithJSON(w, http.StatusOK, friend)
+}
+
+func (s *Server) getFriendsHandler(w http.ResponseWriter, r *http.Request) {
+	UserID := r.PathValue("userId")
+	friends, err := s.db.GetFriends(r.Context(), UserID)
+	if err != nil {
+		respondWithError(w, http.StatusInternalServerError, "Couldn't get friends", err)
+		return
+	}
+	respondWithJSON(w, http.StatusOK, friends)
+}

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -10,7 +10,7 @@ func (s *Server) RegisterRoutes() http.Handler {
 	mux := http.NewServeMux()
 
 	// Register routes
-	mux.HandleFunc("GET /", s.HelloWorldHandler)
+	mux.HandleFunc("GET /{$}", s.HelloWorldHandler)
 
 	mux.HandleFunc("GET /health", s.healthHandler)
 
@@ -21,6 +21,11 @@ func (s *Server) RegisterRoutes() http.Handler {
 	mux.HandleFunc("POST /sotd", s.createSotdHandler)
 	mux.HandleFunc("GET /sotd", s.getSotdHandler)
 	mux.HandleFunc("PUT /sotd", s.updateSotdHandler)
+
+	mux.HandleFunc("POST /user/{userId}/friends/requests", s.addFriendHandler)
+	mux.HandleFunc("GET /user/{userId}/friends/requests", s.getFriendRequestsHandler)
+	mux.HandleFunc("POST /user/{userId}/friends/requests/accept", s.acceptFriendHandler)
+	mux.HandleFunc("GET /user/{userId}/friends", s.getFriendsHandler)
 
 	// Wrap the mux with CORS middleware
 	return s.corsMiddleware(mux)

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -18,6 +18,10 @@ func (s *Server) RegisterRoutes() http.Handler {
 	mux.HandleFunc("GET /sotd", s.getSotdHandler)
 	mux.HandleFunc("PUT /sotd", s.updateSotdHandler)
 
+	mux.HandleFunc("POST /sotd", s.createSotdHandler)
+	mux.HandleFunc("GET /sotd", s.getSotdHandler)
+	mux.HandleFunc("PUT /sotd", s.updateSotdHandler)
+
 	// Wrap the mux with CORS middleware
 	return s.corsMiddleware(mux)
 }

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -18,10 +18,6 @@ func (s *Server) RegisterRoutes() http.Handler {
 	mux.HandleFunc("GET /sotd", s.getSotdHandler)
 	mux.HandleFunc("PUT /sotd", s.updateSotdHandler)
 
-	mux.HandleFunc("POST /sotd", s.createSotdHandler)
-	mux.HandleFunc("GET /sotd", s.getSotdHandler)
-	mux.HandleFunc("PUT /sotd", s.updateSotdHandler)
-
 	mux.HandleFunc("POST /user/{userId}/friends/requests", s.addFriendHandler)
 	mux.HandleFunc("GET /user/{userId}/friends/requests", s.getFriendRequestsHandler)
 	mux.HandleFunc("POST /user/{userId}/friends/requests/accept", s.acceptFriendHandler)

--- a/prisma/migrations/20250315082035_change_friend_status/migration.sql
+++ b/prisma/migrations/20250315082035_change_friend_status/migration.sql
@@ -1,0 +1,14 @@
+/*
+  Warnings:
+
+  - The values [blocked] on the enum `FriendStatus` will be removed. If these variants are still used in the database, this will fail.
+
+*/
+-- AlterEnum
+BEGIN;
+CREATE TYPE "FriendStatus_new" AS ENUM ('pending', 'active', 'removed');
+ALTER TABLE "friend" ALTER COLUMN "status" TYPE "FriendStatus_new" USING ("status"::text::"FriendStatus_new");
+ALTER TYPE "FriendStatus" RENAME TO "FriendStatus_old";
+ALTER TYPE "FriendStatus_new" RENAME TO "FriendStatus";
+DROP TYPE "FriendStatus_old";
+COMMIT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -132,7 +132,7 @@ enum StatisticPeriod {
 }
 
 enum FriendStatus {
+    PENDING @map("pending")
     ACTIVE  @map("active")
-    BLOCKED @map("blocked")
     REMOVED @map("removed")
 }


### PR DESCRIPTION
## Features
- Added CRU APIs for Friends
- Prisma migration to update friend status (added `pending`, remove `blocked`)

## Endpoints
- `addFriendHandler`: User sends a request to add a friend, a record is added to `Friend` table with `pending` status. Note that the user who initiates the request will always be user one
- `getFriendRequestsHandler`: The user who gets requested will be able to get pending friend requests
- `acceptFriendHandler`: User can accept the request (or ignore lol)
- `getFriendsHandler`: Both users can now see each other as friends 