### PR TITLE
refactor: sotd routes

### DIFF
--- a/internal/database/db.go
+++ b/internal/database/db.go
@@ -11,7 +11,8 @@ import (
 type Service interface {
 	GetUserByEmail(ctx context.Context, email string) (*db.UserModel, error)
 	CreateSotd(ctx context.Context, userId, trackId, note, mood string) (*db.SongOfTheDayModel, error)
-	GetSotd(ctx context.Context, userId string, date time.Time) (*db.SongOfTheDayModel, error)
+	GetSotdByDate(ctx context.Context, userId string, date time.Time) (*db.SongOfTheDayModel, error)
+	GetAllSotd(ctx context.Context, userId string, limit, offset int) (*PaginatedSotdResponse, error)
 	UpdateSotd(ctx context.Context, sotdId, trackId, note, mood string) (*db.SongOfTheDayModel, error)
 	AddFriend(ctx context.Context, userId, friendId string) (*db.FriendModel, error)
 	GetFriendRequests(ctx context.Context, userId string) ([]FriendWithUsers, error)

--- a/internal/database/db.go
+++ b/internal/database/db.go
@@ -10,7 +10,7 @@ import (
 
 type Service interface {
 	GetUserByEmail(ctx context.Context, email string) (*db.UserModel, error)
-	CreateSotd(ctx context.Context, userID, trackID, note, mood string) (*db.SongOfTheDayModel, error)
+	CreateSotd(ctx context.Context, userId, trackId, note, mood string) (*db.SongOfTheDayModel, error)
 	GetSotd(ctx context.Context, userId string, date time.Time) (*db.SongOfTheDayModel, error)
 	UpdateSotd(ctx context.Context, sotdId, trackId, note, mood string) (*db.SongOfTheDayModel, error)
 	AddFriend(ctx context.Context, userId, friendId string) (*db.FriendModel, error)

--- a/internal/database/sotd.go
+++ b/internal/database/sotd.go
@@ -2,11 +2,20 @@ package database
 
 import (
 	"context"
+	"errors"
 	db "fsd-backend/prisma/db"
 	"time"
 )
 
 func (s *service) CreateSotd(ctx context.Context, userId, trackId, note, mood string) (*db.SongOfTheDayModel, error) {
+	currentDate := time.Now().UTC()
+	sotd, err := s.GetSotd(ctx, userId, currentDate)
+	if err != nil {
+		return nil, err
+	}
+	if sotd != nil {
+		return nil, errors.New("SOTD already exists, please update it instead of creating a new one")
+	}
 	return s.client.SongOfTheDay.CreateOne(
 		db.SongOfTheDay.TrackID.Set(trackId),
 		db.SongOfTheDay.User.Link(db.User.ID.Equals(userId)),

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -14,8 +14,8 @@ func (s *Server) RegisterRoutes() http.Handler {
 
 	mux.HandleFunc("GET /health", s.healthHandler)
 
-	mux.HandleFunc("POST /user/{userId}/sotd", s.createSotdHandler)
-	mux.HandleFunc("GET /user/{userId}/sotd", s.getSotdBydateHandler)
+	mux.HandleFunc("POST /user/{userId}/sotds", s.createSotdHandler)
+	mux.HandleFunc("GET /user/{userId}/sotds/{date}", s.getSotdBydateHandler)
 	mux.HandleFunc("GET /user/{userId}/sotds", s.getSotdsHandler)
 	mux.HandleFunc("PUT /sotd/{sotdId}", s.updateSotdHandler)
 

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -15,7 +15,8 @@ func (s *Server) RegisterRoutes() http.Handler {
 	mux.HandleFunc("GET /health", s.healthHandler)
 
 	mux.HandleFunc("POST /user/{userId}/sotd", s.createSotdHandler)
-	mux.HandleFunc("GET /user/{userId}/sotd", s.getSotdHandler)
+	mux.HandleFunc("GET /user/{userId}/sotd", s.getSotdBydateHandler)
+	mux.HandleFunc("GET /user/{userId}/sotds", s.getSotdsHandler)
 	mux.HandleFunc("PUT /sotd/{sotdId}", s.updateSotdHandler)
 
 	mux.HandleFunc("POST /user/{userId}/friends/requests", s.addFriendHandler)

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -14,9 +14,9 @@ func (s *Server) RegisterRoutes() http.Handler {
 
 	mux.HandleFunc("GET /health", s.healthHandler)
 
-	mux.HandleFunc("POST /sotd", s.createSotdHandler)
-	mux.HandleFunc("GET /sotd", s.getSotdHandler)
-	mux.HandleFunc("PUT /sotd", s.updateSotdHandler)
+	mux.HandleFunc("POST /user/{userId}/sotd", s.createSotdHandler)
+	mux.HandleFunc("GET /user/{userId}/sotd", s.getSotdHandler)
+	mux.HandleFunc("PUT /sotd/{sotdId}", s.updateSotdHandler)
 
 	mux.HandleFunc("POST /user/{userId}/friends/requests", s.addFriendHandler)
 	mux.HandleFunc("GET /user/{userId}/friends/requests", s.getFriendRequestsHandler)

--- a/internal/server/sotd_handler.go
+++ b/internal/server/sotd_handler.go
@@ -35,7 +35,7 @@ func (s *Server) createSotdHandler(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) getSotdBydateHandler(w http.ResponseWriter, r *http.Request) {
 	UserID := r.PathValue("userId")
-	Date := r.URL.Query().Get("date")
+	Date := r.PathValue("date")
 
 	UnixTime, err := strconv.ParseInt(Date, 10, 64)
 	if err != nil {

--- a/internal/server/sotd_handler.go
+++ b/internal/server/sotd_handler.go
@@ -33,7 +33,7 @@ func (s *Server) createSotdHandler(w http.ResponseWriter, r *http.Request) {
 	respondWithJSON(w, http.StatusCreated, sotd)
 }
 
-func (s *Server) getSotdHandler(w http.ResponseWriter, r *http.Request) {
+func (s *Server) getSotdBydateHandler(w http.ResponseWriter, r *http.Request) {
 	UserID := r.PathValue("userId")
 	Date := r.URL.Query().Get("date")
 
@@ -45,13 +45,36 @@ func (s *Server) getSotdHandler(w http.ResponseWriter, r *http.Request) {
 
 	ParsedDate := time.Unix(UnixTime, 0).UTC()
 
-	sotd, err := s.db.GetSotd(r.Context(), UserID, ParsedDate)
+	sotd, err := s.db.GetSotdByDate(r.Context(), UserID, ParsedDate)
 	if err != nil {
 		respondWithError(w, http.StatusInternalServerError, "Failed to get Sotd", err)
 		return
 	}
 
 	respondWithJSON(w, http.StatusOK, sotd)
+}
+
+func (s *Server) getSotdsHandler(w http.ResponseWriter, r *http.Request) {
+	UserID := r.PathValue("userId")
+	limitParam := r.URL.Query().Get("limit")
+	offsetParam := r.URL.Query().Get("offset")
+
+	limit, err := strconv.Atoi(limitParam)
+	if err != nil || limit <= 0 {
+		limit = 10
+	}
+
+	offset, err := strconv.Atoi(offsetParam)
+	if err != nil || offset < 0 {
+		offset = 0
+	}
+
+	sotds, err := s.db.GetAllSotd(r.Context(), UserID, limit, offset)
+	if err != nil {
+		respondWithError(w, http.StatusInternalServerError, "Couldn't fetch Song of the Day entries", err)
+		return
+	}
+	respondWithJSON(w, http.StatusOK, sotds)
 }
 
 func (s *Server) updateSotdHandler(w http.ResponseWriter, r *http.Request) {

--- a/internal/server/sotd_handler.go
+++ b/internal/server/sotd_handler.go
@@ -8,8 +8,9 @@ import (
 )
 
 func (s *Server) createSotdHandler(w http.ResponseWriter, r *http.Request) {
+	UserID := r.PathValue("userId")
+
 	type parameters struct {
-		UserID  string `json:"user_id"`
 		TrackID string `json:"track_id"`
 		Note    string `json:"note"`
 		Mood    string `json:"mood"`
@@ -23,7 +24,7 @@ func (s *Server) createSotdHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	sotd, err := s.db.CreateSotd(r.Context(), params.UserID, params.TrackID, params.Note, params.Mood)
+	sotd, err := s.db.CreateSotd(r.Context(), UserID, params.TrackID, params.Note, params.Mood)
 	if err != nil {
 		respondWithError(w, http.StatusInternalServerError, "Failed to create Sotd", err)
 		return
@@ -33,18 +34,18 @@ func (s *Server) createSotdHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) getSotdHandler(w http.ResponseWriter, r *http.Request) {
-	userId := r.URL.Query().Get("user_id")
-	date := r.URL.Query().Get("date")
+	UserID := r.PathValue("userId")
+	Date := r.URL.Query().Get("date")
 
-	unixTime, err := strconv.ParseInt(date, 10, 64)
+	UnixTime, err := strconv.ParseInt(Date, 10, 64)
 	if err != nil {
 		http.Error(w, "Invalid Unix timestamp format", http.StatusBadRequest)
 		return
 	}
 
-	parsedDate := time.Unix(unixTime, 0).UTC()
+	ParsedDate := time.Unix(UnixTime, 0).UTC()
 
-	sotd, err := s.db.GetSotd(r.Context(), userId, parsedDate)
+	sotd, err := s.db.GetSotd(r.Context(), UserID, ParsedDate)
 	if err != nil {
 		respondWithError(w, http.StatusInternalServerError, "Failed to get Sotd", err)
 		return
@@ -54,8 +55,9 @@ func (s *Server) getSotdHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) updateSotdHandler(w http.ResponseWriter, r *http.Request) {
+	SotdID := r.PathValue("sotdId")
+
 	type parameters struct {
-		SotdID  string `json:"sotd_id"`
 		TrackID string `json:"track_id"`
 		Note    string `json:"note"`
 		Mood    string `json:"mood"`
@@ -69,7 +71,7 @@ func (s *Server) updateSotdHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	sotd, err := s.db.UpdateSotd(r.Context(), params.SotdID, params.TrackID, params.Note, params.Mood)
+	sotd, err := s.db.UpdateSotd(r.Context(), SotdID, params.TrackID, params.Note, params.Mood)
 	if err != nil {
 		respondWithError(w, http.StatusInternalServerError, "Failed to update Sotd", err)
 		return

--- a/prisma/migrations/20250315141646_change_set_at_to_string/migration.sql
+++ b/prisma/migrations/20250315141646_change_set_at_to_string/migration.sql
@@ -1,0 +1,12 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[user_id,setAt]` on the table `song_of_the_day` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- AlterTable
+ALTER TABLE "song_of_the_day" ALTER COLUMN "setAt" DROP DEFAULT,
+ALTER COLUMN "setAt" SET DATA TYPE TEXT;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "song_of_the_day_user_id_setAt_key" ON "song_of_the_day"("user_id", "setAt");

--- a/prisma/migrations/20250315141721_remove_unnecessary_mapping/migration.sql
+++ b/prisma/migrations/20250315141721_remove_unnecessary_mapping/migration.sql
@@ -1,0 +1,62 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `user_one_id` on the `friend` table. All the data in the column will be lost.
+  - You are about to drop the column `user_two_id` on the `friend` table. All the data in the column will be lost.
+  - You are about to drop the column `user_id` on the `song_of_the_day` table. All the data in the column will be lost.
+  - You are about to drop the column `photo_url` on the `user` table. All the data in the column will be lost.
+  - You are about to drop the column `user_id` on the `user_statistic` table. All the data in the column will be lost.
+  - A unique constraint covering the columns `[userId,setAt]` on the table `song_of_the_day` will be added. If there are existing duplicate values, this will fail.
+  - Added the required column `userOneId` to the `friend` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `userTwoId` to the `friend` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `userId` to the `song_of_the_day` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `userId` to the `user_statistic` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- DropForeignKey
+ALTER TABLE "friend" DROP CONSTRAINT "friend_user_one_id_fkey";
+
+-- DropForeignKey
+ALTER TABLE "friend" DROP CONSTRAINT "friend_user_two_id_fkey";
+
+-- DropForeignKey
+ALTER TABLE "song_of_the_day" DROP CONSTRAINT "song_of_the_day_user_id_fkey";
+
+-- DropForeignKey
+ALTER TABLE "user_statistic" DROP CONSTRAINT "user_statistic_user_id_fkey";
+
+-- DropIndex
+DROP INDEX "song_of_the_day_user_id_setAt_key";
+
+-- AlterTable
+ALTER TABLE "friend" DROP COLUMN "user_one_id",
+DROP COLUMN "user_two_id",
+ADD COLUMN     "userOneId" TEXT NOT NULL,
+ADD COLUMN     "userTwoId" TEXT NOT NULL;
+
+-- AlterTable
+ALTER TABLE "song_of_the_day" DROP COLUMN "user_id",
+ADD COLUMN     "userId" TEXT NOT NULL;
+
+-- AlterTable
+ALTER TABLE "user" DROP COLUMN "photo_url",
+ADD COLUMN     "photoUrl" TEXT;
+
+-- AlterTable
+ALTER TABLE "user_statistic" DROP COLUMN "user_id",
+ADD COLUMN     "userId" TEXT NOT NULL;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "song_of_the_day_userId_setAt_key" ON "song_of_the_day"("userId", "setAt");
+
+-- AddForeignKey
+ALTER TABLE "friend" ADD CONSTRAINT "friend_userOneId_fkey" FOREIGN KEY ("userOneId") REFERENCES "user"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "friend" ADD CONSTRAINT "friend_userTwoId_fkey" FOREIGN KEY ("userTwoId") REFERENCES "user"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "song_of_the_day" ADD CONSTRAINT "song_of_the_day_userId_fkey" FOREIGN KEY ("userId") REFERENCES "user"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "user_statistic" ADD CONSTRAINT "user_statistic_userId_fkey" FOREIGN KEY ("userId") REFERENCES "user"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -65,7 +65,7 @@ model User {
 
     username         String?         @unique
     bio              String?
-    photoUrl         String?         @map("photo_url")
+    photoUrl         String?
     friendsInitiated Friend[]        @relation("UserOne")
     friendsReceived  Friend[]        @relation("UserTwo")
     songOfTheDay     SongOfTheDay[]
@@ -77,8 +77,8 @@ model User {
 model Friend {
     id        String       @id @default(cuid())
     status    FriendStatus
-    userOneId String       @map("user_one_id")
-    userTwoId String       @map("user_two_id")
+    userOneId String
+    userTwoId String
     createdAt DateTime     @default(now())
     updatedAt DateTime     @updatedAt
 
@@ -90,22 +90,23 @@ model Friend {
 
 model SongOfTheDay {
     id        String   @id @default(cuid())
-    userId    String   @map("user_id")
+    userId    String
     trackId   String
     note      String?
     mood      String?
-    setAt     DateTime @default(now())
+    setAt     String
     createdAt DateTime @default(now())
     updatedAt DateTime @updatedAt
 
     user User @relation(fields: [userId], references: [id])
 
+    @@unique([userId, setAt])
     @@map("song_of_the_day")
 }
 
 model UserStatistic {
     id            String          @id @default(cuid())
-    userId        String          @map("user_id")
+    userId        String
     period        StatisticPeriod
     totalTracks   Int             @default(0)
     totalDuration Int             @default(0)


### PR DESCRIPTION
## Features
- refactor routes to follow best practices
- add `getSotdsHandler` to get all sotds for a user (this endpoint is paginated)
- change `setAt` in sotd table to string and make it unique (each user can only have 1 sotd entry per day, any further changes should go though the `PUT` sotd endpoint)
- remove unnecessary mapping in db columns 