### PR TITLE
feat: basic user stats endpoints

### DIFF
--- a/internal/database/db.go
+++ b/internal/database/db.go
@@ -9,7 +9,9 @@ import (
 )
 
 type Service interface {
-	GetUserByEmail(ctx context.Context, email string) (*db.UserModel, error)
+	GetUserById(ctx context.Context, userId string) (*db.UserModel, error)
+	CreateUserStatistic(ctx context.Context, userId string, period db.StatisticPeriod, totalTracks, totalDuration, uniqueArtists int, vibe string, topArtistsIds, topTracksIds, topAlbumsIds []string) (*db.UserStatisticModel, error)
+	GetUserStatisticByPeriod(ctx context.Context, userId string, period db.StatisticPeriod) ([]db.UserStatisticModel, error)
 	CreateSotd(ctx context.Context, userId, trackId, note, mood string) (*db.SongOfTheDayModel, error)
 	GetSotdByDate(ctx context.Context, userId string, date time.Time) (*db.SongOfTheDayModel, error)
 	GetAllSotd(ctx context.Context, userId string, limit, offset int) (*PaginatedSotdResponse, error)
@@ -42,4 +44,8 @@ func New() Service {
 		client: client,
 	}
 	return dbInstance
+}
+
+func (s *service) Close() error {
+	return s.client.Prisma.Disconnect()
 }

--- a/internal/database/friend.go
+++ b/internal/database/friend.go
@@ -21,9 +21,9 @@ type FriendWithUsers struct {
 	UpdatedAt string          `json:"updatedAt"`
 }
 
-func (s *service) AddFriend(ctx context.Context, userID, friendID string) (*db.FriendModel, error) {
-	userOne := userID
-	userTwo := friendID
+func (s *service) AddFriend(ctx context.Context, userId, friendId string) (*db.FriendModel, error) {
+	userOne := userId
+	userTwo := friendId
 	existingFriend, err := s.client.Friend.FindFirst(
 		db.Friend.Or(
 			db.Friend.And(

--- a/internal/database/user.go
+++ b/internal/database/user.go
@@ -8,9 +8,30 @@ import (
 	db "fsd-backend/prisma/db"
 )
 
-func (s *service) GetUserByEmail(ctx context.Context, email string) (*db.UserModel, error) {
+func (s *service) GetUserById(ctx context.Context, userId string) (*db.UserModel, error) {
 	return s.client.User.FindUnique(
-		db.User.Email.Equals(email),
+		db.User.ID.Equals(userId),
+	).Exec(ctx)
+}
+
+func (s *service) CreateUserStatistic(ctx context.Context, userId string, period db.StatisticPeriod, totalTracks, totalDuration, uniqueArtists int, vibe string, topArtistsIds, topTracksIds, topAlbumsIds []string) (*db.UserStatisticModel, error) {
+	return s.client.UserStatistic.CreateOne(
+		db.UserStatistic.Period.Set(period),
+		db.UserStatistic.User.Link(db.User.ID.Equals(userId)),
+		db.UserStatistic.TotalTracks.Set(totalTracks),
+		db.UserStatistic.TotalDuration.Set(totalDuration),
+		db.UserStatistic.UniqueArtists.Set(uniqueArtists),
+		db.UserStatistic.Vibe.Set(vibe),
+		db.UserStatistic.TopArtistsIds.Set(topArtistsIds),
+		db.UserStatistic.TopTracksIds.Set(topTracksIds),
+		db.UserStatistic.TopAlbumsIds.Set(topAlbumsIds),
+	).Exec(ctx)
+}
+
+func (s *service) GetUserStatisticByPeriod(ctx context.Context, userId string, period db.StatisticPeriod) ([]db.UserStatisticModel, error) {
+	return s.client.UserStatistic.FindMany(
+		db.UserStatistic.UserID.Equals(userId),
+		db.UserStatistic.Period.Equals(period),
 	).Exec(ctx)
 }
 
@@ -32,8 +53,4 @@ func (s *service) Health() map[string]string {
 	stats["status"] = "up"
 	stats["message"] = "Database connection is healthy"
 	return stats
-}
-
-func (s *service) Close() error {
-	return s.client.Prisma.Disconnect()
 }

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -14,6 +14,10 @@ func (s *Server) RegisterRoutes() http.Handler {
 
 	mux.HandleFunc("GET /health", s.healthHandler)
 
+	mux.HandleFunc("GET /user/{userId}", s.getUserHandler)
+	mux.HandleFunc("POST /user/{userId}/statistics", s.createUserStatisticHandler)
+	mux.HandleFunc("GET /user/{userId}/statistics/{period}", s.getUserStatisticByPeriodHandler)
+
 	mux.HandleFunc("POST /user/{userId}/sotds", s.createSotdHandler)
 	mux.HandleFunc("GET /user/{userId}/sotds/{date}", s.getSotdBydateHandler)
 	mux.HandleFunc("GET /user/{userId}/sotds", s.getSotdsHandler)

--- a/internal/server/user_handler.go
+++ b/internal/server/user_handler.go
@@ -12,10 +12,10 @@ func (s *Server) getUserHandler(w http.ResponseWriter, r *http.Request) {
 	UserID := r.PathValue("userId")
 	user, err := s.db.GetUserById(r.Context(), UserID)
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		respondWithError(w, http.StatusInternalServerError, "Couldn't get user profile details", err)
 		return
 	}
-	json.NewEncoder(w).Encode(user)
+	respondWithJSON(w, http.StatusCreated, user)
 }
 
 func (s *Server) createUserStatisticHandler(w http.ResponseWriter, r *http.Request) {
@@ -41,10 +41,10 @@ func (s *Server) createUserStatisticHandler(w http.ResponseWriter, r *http.Reque
 
 	userStatistic, err := s.db.CreateUserStatistic(r.Context(), UserID, params.Period, params.TotalTracks, params.TotalDuration, params.UniqueArtists, params.Vibe, params.TopArtistsIds, params.TopTracksIds, params.TopAlbumsIds)
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		respondWithError(w, http.StatusInternalServerError, "Failed to create user statistics", err)
 		return
 	}
-	json.NewEncoder(w).Encode(userStatistic)
+	respondWithJSON(w, http.StatusCreated, userStatistic)
 }
 
 func (s *Server) getUserStatisticByPeriodHandler(w http.ResponseWriter, r *http.Request) {
@@ -52,8 +52,8 @@ func (s *Server) getUserStatisticByPeriodHandler(w http.ResponseWriter, r *http.
 	Period := r.PathValue("period")
 	userStatistic, err := s.db.GetUserStatisticByPeriod(r.Context(), UserID, db.StatisticPeriod(strings.ToUpper(Period)))
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		respondWithError(w, http.StatusInternalServerError, "Failed to get user statistics", err)
 		return
 	}
-	json.NewEncoder(w).Encode(userStatistic)
+	respondWithJSON(w, http.StatusCreated, userStatistic)
 }

--- a/internal/server/user_handler.go
+++ b/internal/server/user_handler.go
@@ -1,0 +1,59 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+
+	db "fsd-backend/prisma/db"
+)
+
+func (s *Server) getUserHandler(w http.ResponseWriter, r *http.Request) {
+	UserID := r.PathValue("userId")
+	user, err := s.db.GetUserById(r.Context(), UserID)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	json.NewEncoder(w).Encode(user)
+}
+
+func (s *Server) createUserStatisticHandler(w http.ResponseWriter, r *http.Request) {
+	UserID := r.PathValue("userId")
+
+	type parameters struct {
+		Period        db.StatisticPeriod `json:"period"`
+		TotalTracks   int                `json:"total_tracks"`
+		TotalDuration int                `json:"total_duration"`
+		UniqueArtists int                `json:"unique_artists"`
+		Vibe          string             `json:"vibe"`
+		TopArtistsIds []string           `json:"top_artists_ids"`
+		TopTracksIds  []string           `json:"top_tracks_ids"`
+		TopAlbumsIds  []string           `json:"top_albums_ids"`
+	}
+	decoder := json.NewDecoder(r.Body)
+	params := parameters{}
+	err := decoder.Decode(&params)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	userStatistic, err := s.db.CreateUserStatistic(r.Context(), UserID, params.Period, params.TotalTracks, params.TotalDuration, params.UniqueArtists, params.Vibe, params.TopArtistsIds, params.TopTracksIds, params.TopAlbumsIds)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	json.NewEncoder(w).Encode(userStatistic)
+}
+
+func (s *Server) getUserStatisticByPeriodHandler(w http.ResponseWriter, r *http.Request) {
+	UserID := r.PathValue("userId")
+	Period := r.PathValue("period")
+	userStatistic, err := s.db.GetUserStatisticByPeriod(r.Context(), UserID, db.StatisticPeriod(strings.ToUpper(Period)))
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	json.NewEncoder(w).Encode(userStatistic)
+}


### PR DESCRIPTION
## Features
- Added endpoint to retrieve user profile details
- Added CR APIs for User Stats (spotify wraps)

## Notes
Any idea on how to automatically compute and store user statistics for different periods? Do we need cron job to compute the statistics at different periods and where (BE, FE, cloud?) is this handled?