### PR TITLE
feat: spotify integration

### DIFF
--- a/internal/database/db.go
+++ b/internal/database/db.go
@@ -10,6 +10,7 @@ import (
 
 type Service interface {
 	GetUserById(ctx context.Context, userId string) (*db.UserModel, error)
+	GetUserAccountByUserId(ctx context.Context, userId string) (*db.AccountModel, error)
 	CreateUserStatistic(ctx context.Context, userId string, period db.StatisticPeriod, totalTracks, totalDuration, uniqueArtists int, vibe string, topArtistsIds, topTracksIds, topAlbumsIds []string) (*db.UserStatisticModel, error)
 	GetUserStatisticByPeriod(ctx context.Context, userId string, period db.StatisticPeriod) ([]db.UserStatisticModel, error)
 	CreateSotd(ctx context.Context, userId, trackId, note, mood string) (*db.SongOfTheDayModel, error)

--- a/internal/database/user.go
+++ b/internal/database/user.go
@@ -14,6 +14,12 @@ func (s *service) GetUserById(ctx context.Context, userId string) (*db.UserModel
 	).Exec(ctx)
 }
 
+func (s * service) GetUserAccountByUserId(ctx context.Context, userId string) (*db.AccountModel, error) {
+	return s.client.Account.FindFirst(
+		db.Account.UserID.Equals(userId),
+	).Exec(ctx)
+}
+
 func (s *service) CreateUserStatistic(ctx context.Context, userId string, period db.StatisticPeriod, totalTracks, totalDuration, uniqueArtists int, vibe string, topArtistsIds, topTracksIds, topAlbumsIds []string) (*db.UserStatisticModel, error) {
 	return s.client.UserStatistic.CreateOne(
 		db.UserStatistic.Period.Set(period),

--- a/internal/models/sotd.go
+++ b/internal/models/sotd.go
@@ -1,0 +1,13 @@
+package models
+
+type SotdEntry struct {
+	ID        string `json:"id"`
+	UserID    string `json:"userId"`
+	TrackID   string `json:"trackId"`
+	Note      string `json:"note"`
+	Mood      string `json:"mood"`
+	SetAt     string `json:"setAt"`
+	CreatedAt string `json:"createdAt"`
+	UpdatedAt string `json:"updatedAt"`
+	Track     Track  `json:"track"`
+}

--- a/internal/models/spotify.go
+++ b/internal/models/spotify.go
@@ -21,30 +21,33 @@ type Followers struct {
 }
 
 type Track struct {
-	ID          string   `json:"id"`
-	Name        string   `json:"name"`
-	Artists     []Artist `json:"artists"`
-	Album       Album    `json:"album"`
-	DurationMs  int      `json:"duration_ms"`
-	Popularity  int      `json:"popularity"`
-	PreviewURL  string   `json:"preview_url"`
-	ExternalURL string   `json:"external_urls.spotify"`
+	ID         string             `json:"id"`
+	Name       string             `json:"name"`
+	Artists    []ArtistSimplified `json:"artists"`
+	Album      Album              `json:"album"`
+	DurationMs int                `json:"duration_ms"`
+	Popularity int                `json:"popularity"`
 }
 
 type Artist struct {
-	ID          string  `json:"id"`
-	Name        string  `json:"name"`
-	Images      []Image `json:"images"`
-	Popularity  int     `json:"popularity"`
-	ExternalURL string  `json:"external_urls.spotify"`
+	ID         string   `json:"id"`
+	Name       string   `json:"name"`
+	Genres     []string `json:"genres"`
+	Images     []Image  `json:"images"`
+	Popularity int      `json:"popularity"`
+}
+
+type ArtistSimplified struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
 }
 
 type Album struct {
 	ID          string  `json:"id"`
 	Name        string  `json:"name"`
+	TotalTracks int     `json:"total_tracks"`
 	Images      []Image `json:"images"`
 	ReleaseDate string  `json:"release_date"`
-	ExternalURL string  `json:"external_urls.spotify"`
 }
 
 type Playlist struct {
@@ -54,7 +57,6 @@ type Playlist struct {
 	Images      []Image        `json:"images"`
 	Owner       SpotifyUser    `json:"owner"`
 	Tracks      PlaylistTracks `json:"tracks"`
-	ExternalURL string         `json:"external_urls.spotify"`
 }
 
 type PlaylistTracks struct {

--- a/internal/models/spotify.go
+++ b/internal/models/spotify.go
@@ -65,11 +65,19 @@ type PlaylistTracks struct {
 }
 
 type RecentlyPlayed struct {
-	Items []PlayHistory `json:"items"`
-	Next  string        `json:"next"`
+	Items   []PlayHistory `json:"items"`
+	Total   int           `json:"total"`
+	Next    string        `json:"next"`
+	Limit   int           `json:"limit"`
+	Cursors Cursors       `json:"cursors"`
 }
 
 type PlayHistory struct {
 	PlayedAt string `json:"played_at"`
 	Track    Track  `json:"track"`
+}
+
+type Cursors struct {
+	After  string `json:"after"`
+	Before string `json:"before"`
 }

--- a/internal/models/spotify.go
+++ b/internal/models/spotify.go
@@ -1,0 +1,73 @@
+package models
+
+type SpotifyUser struct {
+	ID          string    `json:"id"`
+	DisplayName string    `json:"display_name"`
+	Email       string    `json:"email"`
+	Product     string    `json:"product"`
+	Country     string    `json:"country"`
+	Images      []Image   `json:"images"`
+	Followers   Followers `json:"followers"`
+}
+
+type Image struct {
+	URL    string `json:"url"`
+	Height int    `json:"height"`
+	Width  int    `json:"width"`
+}
+
+type Followers struct {
+	Total int `json:"total"`
+}
+
+type Track struct {
+	ID          string   `json:"id"`
+	Name        string   `json:"name"`
+	Artists     []Artist `json:"artists"`
+	Album       Album    `json:"album"`
+	DurationMs  int      `json:"duration_ms"`
+	Popularity  int      `json:"popularity"`
+	PreviewURL  string   `json:"preview_url"`
+	ExternalURL string   `json:"external_urls.spotify"`
+}
+
+type Artist struct {
+	ID          string  `json:"id"`
+	Name        string  `json:"name"`
+	Images      []Image `json:"images"`
+	Popularity  int     `json:"popularity"`
+	ExternalURL string  `json:"external_urls.spotify"`
+}
+
+type Album struct {
+	ID          string  `json:"id"`
+	Name        string  `json:"name"`
+	Images      []Image `json:"images"`
+	ReleaseDate string  `json:"release_date"`
+	ExternalURL string  `json:"external_urls.spotify"`
+}
+
+type Playlist struct {
+	ID          string         `json:"id"`
+	Name        string         `json:"name"`
+	Description string         `json:"description"`
+	Images      []Image        `json:"images"`
+	Owner       SpotifyUser    `json:"owner"`
+	Tracks      PlaylistTracks `json:"tracks"`
+	ExternalURL string         `json:"external_urls.spotify"`
+}
+
+type PlaylistTracks struct {
+	Total int     `json:"total"`
+	Items []Track `json:"items"`
+}
+
+type RecentlyPlayed struct {
+	Items []PlayHistory `json:"items"`
+	Next  string        `json:"next"`
+}
+
+type PlayHistory struct {
+	PlayedAt string `json:"played_at"`
+	Track    Track  `json:"track"`
+}

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -22,6 +22,7 @@ func (s *Server) RegisterRoutes() http.Handler {
 	mux.HandleFunc("GET /user/{userId}/sotds/{date}", s.getSotdBydateHandler)
 	mux.HandleFunc("GET /user/{userId}/sotds", s.getSotdsHandler)
 	mux.HandleFunc("PUT /sotd/{sotdId}", s.updateSotdHandler)
+	mux.HandleFunc("GET /user/{userId}/sotds/recommended", s.getRecommendedSotdsHandler)
 
 	mux.HandleFunc("POST /user/{userId}/friends/requests", s.addFriendHandler)
 	mux.HandleFunc("GET /user/{userId}/friends/requests", s.getFriendRequestsHandler)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -2,7 +2,6 @@ package server
 
 import (
 	"fmt"
-	"log"
 	"net/http"
 	"os"
 	"strconv"
@@ -11,24 +10,26 @@ import (
 	_ "github.com/joho/godotenv/autoload"
 
 	"fsd-backend/internal/database"
+	"fsd-backend/internal/spotify"
 )
 
 type Server struct {
-	port      int
-	jwtSecret string
-	db        database.Service
+	port    int
+	db      database.Service
+	spotify spotify.Service
 }
 
 func NewServer() *http.Server {
 	port, _ := strconv.Atoi(os.Getenv("PORT"))
-	jwtSecret := os.Getenv("JWT_SECRET")
-	if jwtSecret == "" {
-		log.Fatal("JWT_SECRET must be set")
-	}
+
+	spotifyConfig := spotify.DefaultConfig()
+	spotifyConfig.ClientID = os.Getenv("SPOTIFY_CLIENT_ID")
+	spotifyConfig.ClientSecret = os.Getenv("SPOTIFY_CLIENT_SECRET")
+
 	NewServer := &Server{
-		port:      port,
-		jwtSecret: jwtSecret,
-		db:        database.New(),
+		port:    port,
+		db:      database.New(),
+		spotify: spotify.NewService(spotifyConfig),
 	}
 
 	// Declare Server config

--- a/internal/server/sotd_handler.go
+++ b/internal/server/sotd_handler.go
@@ -5,6 +5,8 @@ import (
 	"net/http"
 	"strconv"
 	"time"
+
+	"fsd-backend/internal/models"
 )
 
 func (s *Server) createSotdHandler(w http.ResponseWriter, r *http.Request) {
@@ -51,7 +53,34 @@ func (s *Server) getSotdBydateHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	respondWithJSON(w, http.StatusOK, sotd)
+	user, err := s.db.GetUserAccountByUserId(r.Context(), UserID)
+	if err != nil {
+		respondWithError(w, http.StatusInternalServerError, "Failed to get User", err)
+		return
+	}
+
+	accessToken, _ := user.AccessToken()
+	track, err := s.spotify.GetTrackByID(r.Context(), accessToken, sotd.TrackID)
+	if err != nil {
+		respondWithError(w, http.StatusInternalServerError, "Failed to get Track", err)
+		return
+	}
+
+	note, _ := sotd.Note()
+	mood, _ := sotd.Mood()
+	formattedSotd := models.SotdEntry{
+		ID:        sotd.ID,
+		UserID:    sotd.UserID,
+		TrackID:   sotd.TrackID,
+		Note:      note,
+		Mood:      mood,
+		SetAt:     sotd.SetAt,
+		CreatedAt: sotd.CreatedAt.String(),
+		UpdatedAt: sotd.UpdatedAt.String(),
+		Track:     *track,
+	}
+
+	respondWithJSON(w, http.StatusOK, formattedSotd)
 }
 
 func (s *Server) getSotdsHandler(w http.ResponseWriter, r *http.Request) {
@@ -74,7 +103,51 @@ func (s *Server) getSotdsHandler(w http.ResponseWriter, r *http.Request) {
 		respondWithError(w, http.StatusInternalServerError, "Couldn't fetch Song of the Day entries", err)
 		return
 	}
-	respondWithJSON(w, http.StatusOK, sotds)
+
+	user, err := s.db.GetUserAccountByUserId(r.Context(), UserID)
+	if err != nil {
+		respondWithError(w, http.StatusInternalServerError, "Failed to get User", err)
+		return
+	}
+	accessToken, _ := user.AccessToken()
+
+	trackIDs := make([]string, len(sotds.SotdEntries))
+	for i, entry := range sotds.SotdEntries {
+		trackIDs[i] = entry.TrackID
+	}
+
+	tracks, err := s.spotify.GetTracksByIDs(r.Context(), accessToken, trackIDs)
+	if err != nil {
+		respondWithError(w, http.StatusInternalServerError, "Failed to fetch tracks", err)
+		return
+	}
+
+	trackMap := make(map[string]models.Track, len(tracks))
+	for _, track := range tracks {
+		trackMap[track.ID] = track
+	}
+
+	grouped := make(map[string][]models.SotdEntry)
+	for _, entry := range sotds.SotdEntries {
+		note, _ := entry.Note()
+		mood, _ := entry.Mood()
+		grouped[entry.SetAt] = append(grouped[entry.SetAt], models.SotdEntry{
+			ID:        entry.ID,
+			UserID:    entry.UserID,
+			TrackID:   entry.TrackID,
+			Note:      note,
+			Mood:      mood,
+			SetAt:     entry.SetAt,
+			CreatedAt: entry.CreatedAt.Format(time.RFC3339),
+			UpdatedAt: entry.UpdatedAt.Format(time.RFC3339),
+			Track:     trackMap[entry.TrackID],
+		})
+	}
+
+	respondWithJSON(w, http.StatusOK, map[string]interface{}{
+		"hasMore": sotds.HasMore,
+		"entries": grouped,
+	})
 }
 
 func (s *Server) updateSotdHandler(w http.ResponseWriter, r *http.Request) {

--- a/internal/server/sotd_handler.go
+++ b/internal/server/sotd_handler.go
@@ -175,3 +175,22 @@ func (s *Server) updateSotdHandler(w http.ResponseWriter, r *http.Request) {
 
 	respondWithJSON(w, http.StatusOK, sotd)
 }
+
+func (s *Server) getRecommendedSotdsHandler(w http.ResponseWriter, r *http.Request) {
+	UserID := r.PathValue("userId")
+
+	user, err := s.db.GetUserAccountByUserId(r.Context(), UserID)
+	if err != nil {
+		respondWithError(w, http.StatusInternalServerError, "Failed to get User", err)
+		return
+	}
+	accessToken, _ := user.AccessToken()
+
+	recentlyPlayed, err := s.spotify.GetUserRecentlyPlayedTracks(r.Context(), accessToken)
+	if err != nil {
+		respondWithError(w, http.StatusInternalServerError, "Failed to get Recently Played Tracks", err)
+		return
+	}
+
+	respondWithJSON(w, http.StatusOK, recentlyPlayed)
+}

--- a/internal/spotify/client.go
+++ b/internal/spotify/client.go
@@ -1,0 +1,44 @@
+package spotify
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+)
+
+type Client struct {
+	httpClient *http.Client
+	baseURL    string
+}
+
+func NewClient(config *Config) *Client {
+	return &Client{
+		httpClient: &http.Client{Timeout: 10 * time.Second},
+		baseURL:    config.BaseURL,
+	}
+}
+
+func (c *Client) request(ctx context.Context, method, endpoint, token string) (*http.Request, error) {
+	url := fmt.Sprintf("%s%s", c.baseURL, endpoint)
+	req, err := http.NewRequestWithContext(ctx, method, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Accept", "application/json")
+	return req, nil
+}
+
+func (c *Client) doJSON(req *http.Request, out interface{}) error {
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 400 {
+		return fmt.Errorf("spotify API error: %s", resp.Status)
+	}
+	return json.NewDecoder(resp.Body).Decode(out)
+}

--- a/internal/spotify/config.go
+++ b/internal/spotify/config.go
@@ -1,0 +1,13 @@
+package spotify
+
+type Config struct {
+	ClientID     string
+	ClientSecret string
+	BaseURL      string
+}
+
+func DefaultConfig() *Config {
+	return &Config{
+		BaseURL: "https://api.spotify.com/v1",
+	}
+}

--- a/internal/spotify/service.go
+++ b/internal/spotify/service.go
@@ -11,6 +11,7 @@ import (
 type Service interface {
 	GetTrackByID(ctx context.Context, token string, itemId string) (*models.Track, error)
 	GetTracksByIDs(ctx context.Context, token string, ids []string) ([]models.Track, error)
+	GetUserRecentlyPlayedTracks(ctx context.Context, token string) (*models.RecentlyPlayed, error)
 }
 
 type service struct {
@@ -60,4 +61,17 @@ func (s *service) GetTracksByIDs(ctx context.Context, token string, ids []string
 		allTracks = append(allTracks, resp.Tracks...)
 	}
 	return allTracks, nil
+}
+
+func (s *service) GetUserRecentlyPlayedTracks(ctx context.Context, token string) (*models.RecentlyPlayed, error) {
+	req, err := s.client.request(ctx, http.MethodGet, "/me/player/recently-played", token)
+	if err != nil {
+		fmt.Println("Error getting user recently played tracks", err)
+		return nil, err
+	}
+	var recentlyPlayed models.RecentlyPlayed
+	if err := s.client.doJSON(req, &recentlyPlayed); err != nil {
+		return nil, err
+	}
+	return &recentlyPlayed, nil
 }

--- a/internal/spotify/service.go
+++ b/internal/spotify/service.go
@@ -1,0 +1,63 @@
+package spotify
+
+import (
+	"context"
+	"fmt"
+	"fsd-backend/internal/models"
+	"net/http"
+	"strings"
+)
+
+type Service interface {
+	GetTrackByID(ctx context.Context, token string, itemId string) (*models.Track, error)
+	GetTracksByIDs(ctx context.Context, token string, ids []string) ([]models.Track, error)
+}
+
+type service struct {
+	client *Client
+}
+
+func NewService(config *Config) Service {
+	return &service{
+		client: NewClient(config),
+	}
+}
+
+func (s *service) GetTrackByID(ctx context.Context, token string, trackId string) (*models.Track, error) {
+	req, err := s.client.request(ctx, http.MethodGet, "/tracks/"+trackId, token)
+	if err != nil {
+		fmt.Println("Error getting track by id", err)
+		return nil, err
+	}
+	var track models.Track
+	if err := s.client.doJSON(req, &track); err != nil {
+		return nil, err
+	}
+	return &track, nil
+}
+
+func (s *service) GetTracksByIDs(ctx context.Context, token string, ids []string) ([]models.Track, error) {
+	// Spotify API limit is 50 ids per request
+	const batchSize = 50
+	var allTracks []models.Track
+	for start := 0; start < len(ids); start += batchSize {
+		end := start + batchSize
+		if end > len(ids) {
+			end = len(ids)
+		}
+		batchIDs := ids[start:end]
+		idParam := strings.Join(batchIDs, ",")
+		req, err := s.client.request(ctx, http.MethodGet, "/tracks?ids="+idParam, token)
+		if err != nil {
+			return nil, err
+		}
+		var resp struct {
+			Tracks []models.Track `json:"tracks"`
+		}
+		if err := s.client.doJSON(req, &resp); err != nil {
+			return nil, err
+		}
+		allTracks = append(allTracks, resp.Tracks...)
+	}
+	return allTracks, nil
+}


### PR DESCRIPTION
## Features
Simple Spotify integration to support:
- the get sotd / sotds endpoint pass back the track’s info instead of just the track ID
- get recommended songs for sotds based on user's recently played tracks

## Notes
The idea of such integration is to eliminate the need of having FE to interact with Spotify's API on the fly